### PR TITLE
added the --version argument.

### DIFF
--- a/hunt_protocol/__init__.py
+++ b/hunt_protocol/__init__.py
@@ -4,7 +4,7 @@ Hunt Protocol — Sovereign Memory for AI Systems
 L0 protocol modules for cryptographically signed, deterministic state management.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from .canonical_json import canonical_dumps, canonical_bytes, canonical_hash
 from .signing import BackpackKeypair, sign_event, verify_event_signature

--- a/hunt_protocol/server.py
+++ b/hunt_protocol/server.py
@@ -15,6 +15,8 @@ import base64
 import datetime
 import json
 import os
+import argparse
+from . import __version__ 
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -569,6 +571,11 @@ def _find_belief_namespace(state: dict, bkey: str) -> str:
 # ---------------------------------------------------------------------------
 
 def main():
+    parser = argparse.ArgumentParser(description="Hunt Protocol MCP Server")
+    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
+    # you can change the other arguments buy adding another parser.add_argument() here if needed :)
+    args = parser.parse_args()
+    
     mcp.run()
 
 

--- a/hunt_protocol/server.py
+++ b/hunt_protocol/server.py
@@ -573,7 +573,7 @@ def _find_belief_namespace(state: dict, bkey: str) -> str:
 def main():
     parser = argparse.ArgumentParser(description="Hunt Protocol MCP Server")
     parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
-    # you can change the other arguments buy adding another parser.add_argument() here if needed :)
+    # you can change the other arguments by adding another parser.add_argument() here if needed :)
     args = parser.parse_args()
     
     mcp.run()


### PR DESCRIPTION
finished what was requested in issue #2. by running hunt-mcp --version, you can now see the version printed as whatever listed in the init file.